### PR TITLE
Updates

### DIFF
--- a/gateway/content/index.html
+++ b/gateway/content/index.html
@@ -8,10 +8,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.2/leaflet.css" integrity="sha512-UkezATkM8unVC0R/Z9Kmq4gorjNoFwLMAWR/1yZpINW08I79jEKx/c8NlLSvvimcu7SL8pgeOnynxfRpe+5QpA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.2/leaflet.js" integrity="sha512-KMraOVM0qMVE0U1OULTpYO4gg5MZgazwPAPyMQWfOkEshpwlLQFCHZ/0lBXyviDNVL+pBGwmeXQnuvGK8Fscvg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-plugins/3.4.0/control/Permalink.min.js" integrity="sha512-wEr+4N2qhQn/6/YACFWVAaKzS2vLeZCWyUJ14MfXGTfHG718QBvOqv9t5xhex+Fnd3VZVd0EWcn9nzRbTLL9bg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-plugins/3.4.0/control/Permalink.Layer.min.js" integrity="sha512-m7ds5hujMwIiJ9yPLnJDR4C3bFeURlrFeHnW+QpsDweqYs8hu0/cYdJFBYtRkWGFpvmF6HkOWSGy7vYP1Rg+BA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-plugins/3.4.0/control/Permalink.Overlay.min.js" integrity="sha512-dIzyCLt0Sg0QpDfLXJZfgwmkbjl5s+ND7uFGW6A7itxuKA241Fzp6fKmCnPLhadqqmjz5i9/1W6aCFPLNSIIXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@0.76.1/dist/L.Control.Locate.min.css" integrity="sha256-9ouZwdHZxE1t+iXfxZD90z8xHQrynHnPJk1UgEPXolI="  crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@0.76.1/dist/L.Control.Locate.min.js" charset="utf-8" integrity="sha256-PJ29AcM0ZkANjcOdpF1jAwZ/eq324NP2cQ05f2wABE0=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 

--- a/gateway/content/index.html
+++ b/gateway/content/index.html
@@ -5,12 +5,12 @@
     <title>OpenStreetMap - CD:NGI Mapping</title>
     <link rel="stylesheet" href="map.css" type="text/css" media="all" />
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.1/leaflet.css" integrity="sha512-UkezATkM8unVC0R/Z9Kmq4gorjNoFwLMAWR/1yZpINW08I79jEKx/c8NlLSvvimcu7SL8pgeOnynxfRpe+5QpA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.1/leaflet.js" integrity="sha512-y6IQOhEalDvx6StYG9hG/64K2vuX3bVJ2Q3sBd0uP2UlhIAwOc9DEFgQ/oz1dQmsc2XbWwhn5MfpT76+1bx2Gg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.2/leaflet.css" integrity="sha512-UkezATkM8unVC0R/Z9Kmq4gorjNoFwLMAWR/1yZpINW08I79jEKx/c8NlLSvvimcu7SL8pgeOnynxfRpe+5QpA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.2/leaflet.js" integrity="sha512-KMraOVM0qMVE0U1OULTpYO4gg5MZgazwPAPyMQWfOkEshpwlLQFCHZ/0lBXyviDNVL+pBGwmeXQnuvGK8Fscvg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-plugins/3.4.0/control/Permalink.min.js" integrity="sha512-wEr+4N2qhQn/6/YACFWVAaKzS2vLeZCWyUJ14MfXGTfHG718QBvOqv9t5xhex+Fnd3VZVd0EWcn9nzRbTLL9bg==" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-plugins/3.4.0/control/Permalink.Layer.min.js" integrity="sha512-m7ds5hujMwIiJ9yPLnJDR4C3bFeURlrFeHnW+QpsDweqYs8hu0/cYdJFBYtRkWGFpvmF6HkOWSGy7vYP1Rg+BA==" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-plugins/3.4.0/control/Permalink.Overlay.min.js" integrity="sha512-dIzyCLt0Sg0QpDfLXJZfgwmkbjl5s+ND7uFGW6A7itxuKA241Fzp6fKmCnPLhadqqmjz5i9/1W6aCFPLNSIIXA==" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-plugins/3.4.0/control/Permalink.min.js" integrity="sha512-wEr+4N2qhQn/6/YACFWVAaKzS2vLeZCWyUJ14MfXGTfHG718QBvOqv9t5xhex+Fnd3VZVd0EWcn9nzRbTLL9bg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-plugins/3.4.0/control/Permalink.Layer.min.js" integrity="sha512-m7ds5hujMwIiJ9yPLnJDR4C3bFeURlrFeHnW+QpsDweqYs8hu0/cYdJFBYtRkWGFpvmF6HkOWSGy7vYP1Rg+BA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-plugins/3.4.0/control/Permalink.Overlay.min.js" integrity="sha512-dIzyCLt0Sg0QpDfLXJZfgwmkbjl5s+ND7uFGW6A7itxuKA241Fzp6fKmCnPLhadqqmjz5i9/1W6aCFPLNSIIXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@0.76.1/dist/L.Control.Locate.min.css" integrity="sha256-9ouZwdHZxE1t+iXfxZD90z8xHQrynHnPJk1UgEPXolI="  crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@0.76.1/dist/L.Control.Locate.min.js" charset="utf-8" integrity="sha256-PJ29AcM0ZkANjcOdpF1jAwZ/eq324NP2cQ05f2wABE0=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/gateway/content/map.js
+++ b/gateway/content/map.js
@@ -29,9 +29,6 @@ function createMap(divName) {
     maxZoom: 19
   }), "OpenStreetMap");
 
-  // Add the permalink control
-  map.addControl(new L.Control.Permalink());
-
   // Add URL hash updating
   new L.Hash(map);
 

--- a/tiler/Dockerfile
+++ b/tiler/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-rc-bullseye
+FROM python:3.11-bullseye
 
 RUN set -eux; \
   apt-get update; \

--- a/tiler/requirements.txt
+++ b/tiler/requirements.txt
@@ -1,6 +1,6 @@
-# Add python 3.11 support to rio-color. Direct dependency should be removed once fix released upstream: https://github.com/mapbox/rio-color/pull/82
-git+https://github.com/Firefishy/rio-color.git@python311-support#egg=rio-color
-cogeo-mosaic==4.1.0
+# use github master while we wait for new release
+git+https://github.com/mapbox/rio-color#egg=rio-color
+cogeo-mosaic==4.1.1
 titiler.core==0.7.1
 titiler.mosaic==0.7.1
-uvicorn==0.18.3
+uvicorn==0.19.0


### PR DESCRIPTION
* Update to Python 3.11.0 (final)
* Update PIP packages to latest compatible.
* Update LeafletJS to 1.9.2
* Remove Leaflet Permalink module as conflicts with hash module.