### PR TITLE
Use github actions to build docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - 'master'
+      - 'main'
+  schedule:
+    # auto update images weekly
+    - cron: '25 3 * * 6'
+
+concurrency:
+  group: ${{ github.workflow }}-{{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    strategy:
+      matrix:
+        image: [gateway, mapimages, mapproxy, tiler]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}-${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: ${{ matrix.image }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 version: "3.9"
 services:
   mapimages:
+    image: ghcr.io/afrith/ngimaps-mapimages
     build: ./mapimages
     volumes:
       - "./tiffs:/usr/share/nginx/html"
 
   tiler:
+    image: ghcr.io/afrith/ngimaps-tiler
     build: ./tiler
     environment:
       - "FIFTYK_MOSAIC_URL=http://mapimages/50k/mosaic-internal.json"
@@ -13,6 +15,7 @@ services:
       - mapimages
 
   mapproxy:
+    image: ghcr.io/afrith/ngimaps-mapproxy
     build: ./mapproxy
     volumes:
       - "./cache:/mapproxy/cache_data"
@@ -25,6 +28,7 @@ services:
       - tiler
 
   seed:
+    image: ghcr.io/afrith/ngimaps-mapproxy
     build: ./mapproxy
     volumes:
       - "./cache:/mapproxy/cache_data"
@@ -35,6 +39,7 @@ services:
     command: mapproxy-seed -f /mapproxy/mapproxy.yaml -s /mapproxy/seed.yaml --concurrency 4
 
   gateway:
+    image: ghcr.io/afrith/ngimaps-gateway
     build: './gateway'
     ports:
       - "8080:80"


### PR DESCRIPTION
This PR added a github actions job to build images and push the images to the github packages registry (`:latest` for default branch, or `:branchname` for testing branches.

`docker compose up` will now use images if available (useful for production environment), alternative you can build images locally using `docker compose build` or `docker compose up --build`

ARM64 and AMD64 images are build.